### PR TITLE
Update: add user_photo to users table

### DIFF
--- a/db/migrate/20220607014415_add_user_photo_to_user.rb
+++ b/db/migrate/20220607014415_add_user_photo_to_user.rb
@@ -1,0 +1,5 @@
+class AddUserPhotoToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :user_photo, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_04_220355) do
+ActiveRecord::Schema.define(version: 2022_06_07_014415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2022_06_04_220355) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "user_photo"
   end
 
   add_foreign_key "items", "users"


### PR DESCRIPTION
Adds a user_photo column to the user table. According to @johnny-bowman the google profile pictures come through as urls so this column takes strings. 

Might have to add/ update a in a few spots once front end starts grabbing profile pics along with names+emails, but the base functionality is there! 

No tests added yet, will add when we know what we're getting from FE.